### PR TITLE
Less code by using more feature of argparse

### DIFF
--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -1,17 +1,9 @@
-import sys
-
-from . import __version__
-from .cli import get_args, get_code
 from .carbon import create_code_image
+from .cli import get_args
 
 
 def main():
     args = get_args()
-    if args.version:
-        print(__version__)
-        sys.exit(0)
-
-    code = get_code(args)
     options = {
         "language": args.language,
         "background": args.background,
@@ -19,7 +11,7 @@ def main():
         "interactive": args.interactive,
         "destination": args.destination,
     }
-    create_code_image(code, **options)
+    create_code_image(args.code, **options)
 
 
 if __name__ == "__main__":

--- a/carbon/carbon.py
+++ b/carbon/carbon.py
@@ -9,20 +9,15 @@ from selenium.webdriver.chrome.options import Options
 load_dotenv()
 
 CARBON_URL = "https://carbon.now.sh?l={language}&code={code}&bg={background}&t={theme}"
-CHROMEDRIVER_PATH = os.environ["CHROMEDRIVER_PATH"]
+CHROMEDRIVER_PATH = os.environ.get("CHROMEDRIVER_PATH", "")
 
 # in case of a slow connection it might take a bit longer to download the image
 SECONDS_SLEEP_BEFORE_DOWNLOAD = int(os.environ.get("SECONDS_SLEEP_BEFORE_DOWNLOAD", 3))
 
-DEFAULT_LANGUAGE = "python"
-DEFAULT_BACKGROUND = "#ABB8C3"
-DEFAULT_THEME = "seti"
-
-
 def _create_carbon_url(code, **kwargs: str) -> str:
-    language = kwargs.get("language") or DEFAULT_LANGUAGE
-    background = kwargs.get("background") or DEFAULT_BACKGROUND
-    theme = kwargs.get("theme") or DEFAULT_THEME
+    language = kwargs.get("language")
+    background = kwargs.get("background")
+    theme = kwargs.get("theme")
 
     url = CARBON_URL.format(
         language=quote_plus(language),

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -3,18 +3,38 @@ import os
 
 import pyperclip
 
+from . import __version__ as version
+
+
+def read_frm_file(filename: str) -> str:
+    if not os.path.isfile(filename):
+        raise argparse.ArgumentTypeError(f"No such file: {filename}")
+    with open(os.path.abspath(filename), mode="rt") as fp:
+        return fp.read()
+
 
 def get_args():
-    parser = argparse.ArgumentParser(description="Create a carbon code image")
+    parser = argparse.ArgumentParser(
+        description="Create a carbon code image",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"%(prog)s {version}"
+    )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("-f", "--file", type=str, help="File with code")
     group.add_argument(
-        "-c", "--clipboard", action="store_true", help="Use code on clipboard"
+        "-f", "--file", type=read_frm_file, help="File with code", dest="code"
     )
-    group.add_argument("-s", "--snippet", type=str, help="Code snippet")
     group.add_argument(
-        "-v", "--version", action="store_true", default=False, help="Show version"
+        "-c",
+        "--clipboard",
+        help="Use code on clipboard",
+        action="store_const",
+        const=pyperclip.paste(),
+        dest="code",
     )
+    group.add_argument("-s", "--snippet", help="Code snippet", dest="code")
+
     parser.add_argument(
         "-i",
         "--interactive",
@@ -22,30 +42,17 @@ def get_args():
         default=False,
         help="Run Selenium in interactive (not headless) mode",
     )
-    parser.add_argument("-l", "--language", type=str, help="Programming language")
-    parser.add_argument("-b", "--background", type=str, help="Background color")
-    parser.add_argument("-t", "--theme", type=str, help="Name of the theme")
+    parser.add_argument(
+        "-l", "--language", help="Programming language", default="python"
+    )
+    parser.add_argument(
+        "-b", "--background", help="Background color", default="#ABB8C3"
+    )
+    parser.add_argument("-t", "--theme", help="Name of the theme", default="seti")
     parser.add_argument(
         "-d",
         "--destination",
-        type=str,
         default=os.getcwd(),
         help="Specify folder where image should be stored (defaults to current directory)",
     )
     return parser.parse_args()
-
-
-def get_code(args: argparse.Namespace) -> str:
-    """
-    Argparse's add_mutually_exclusive_group already guaranteers
-    we get one of clipboard, file or snippet
-    """
-    if args.clipboard:
-        code = pyperclip.paste()
-    elif args.file:
-        with open(args.file) as f:
-            code = f.read()
-    else:
-        code = args.snippet
-
-    return code

--- a/carbon/cli.py
+++ b/carbon/cli.py
@@ -6,7 +6,7 @@ import pyperclip
 from . import __version__ as version
 
 
-def read_frm_file(filename: str) -> str:
+def get_code_from_file(filename: str) -> str:
     if not os.path.isfile(filename):
         raise argparse.ArgumentTypeError(f"No such file: {filename}")
     with open(os.path.abspath(filename), mode="rt") as fp:
@@ -23,7 +23,7 @@ def get_args():
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
-        "-f", "--file", type=read_frm_file, help="File with code", dest="code"
+        "-f", "--file", type=get_code_from_file, help="File with code", dest="code"
     )
     group.add_argument(
         "-c",


### PR DESCRIPTION
HI @bbelderbos,

I added `ArgumentDefaultsHelpFormatter` as it helps to see the default values. Also, I saved the output of different ways you get the code (env, clipboard, file) into one attribute (code) and move the code inside get_code into argparse' type keyword, which allows execution of a custom function.

I also changed this line:
`CHROMEDRIVER_PATH = os.environ.get("CHROMEDRIVER_PATH", "")`
Because for someone like me who does not have the chrome driver, it throws an exception, probably it is a good idea to handle these edges and print a user-friendly error message. Maybe it is a good idea to move the code inside the `__main__` module to `cli`, I mean the `main` function because I think `cli` should be the main command-line endpoint and `__main__ ` should call the `cli.main` function, not vice versa (but maybe it is just matter of taste).


Thanks for your wonderful project 
