### PR TITLE
add disable-dev-shm kwarg to fix codeimag.es heroku crash:

### DIFF
--- a/carbon/carbon.py
+++ b/carbon/carbon.py
@@ -38,9 +38,13 @@ def create_code_image(code: str, **kwargs: str) -> None:
     """Generate a beautiful Carbon code image"""
     options = Options()
     options.headless = not bool(kwargs.get("interactive", False))
+
     destination = kwargs.get("destination", os.getcwd())
     prefs = {"download.default_directory": destination}
     options.add_experimental_option("prefs", prefs)
+
+    if kwargs.get("disable-dev-shm", False):
+        options.add_argument("disable-dev-shm-usage")
 
     url = _create_carbon_url(code, **kwargs)
     with webdriver.Chrome(kwargs["driver_path"], options=options) as driver:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyperclip==1.8.2
-python-dotenv==0.19.0
-selenium==3.141.0
+python-dotenv==0.21.0
+selenium==4.6.1


### PR DESCRIPTION
```
Nov 28 23:09:54 pybites-codeimages app/web.1 selenium.common.exceptions.WebDriverException: Message: unknown error: session deleted because of page crash Nov 28 23:09:54 pybites-codeimages app/web.1 from unknown error: cannot determine loading status Nov 28 23:09:54 pybites-codeimages app/web.1 from tab crashed
Nov 28 23:09:54 pybites-codeimages app/web.1   (Session info: headless chrome=107.0.5304.121)
```

likely this:
https://blog.m157q.tw/posts/2020/09/11/python-selenium-chromedriver-unknown-error-session-deleted-because-of-page-crash/ https://help.heroku.com/DOB4Y0I4/how-do-i-prevent-headless-chromium-from-crashing